### PR TITLE
Improved performance for group merging

### DIFF
--- a/test/unionFindTest.js
+++ b/test/unionFindTest.js
@@ -29,4 +29,19 @@ describe('unionFind', function () {
     assert.equal(false, testUnionFind.inSameGroup(0,2));
     assert.equal(testUnionFind.find(0).getGroupLeader(), testUnionFind.find(1).getGroupLeader());
   });
+
+  it('Groups of size == 2 unioned should now be in the same group and have the same leader', function () {
+    var testUnionFind = new UnionFind([0,1,2,3]);
+    testUnionFind.union(0,1);
+    testUnionFind.union(2,3);
+    testUnionFind.union(0,3);
+    assert.equal(true, testUnionFind.inSameGroup(0,1), "0 and 1 are not in the same group");
+    assert.equal(true, testUnionFind.inSameGroup(1,2), "1 and 2 are not in the same group");
+    assert.equal(true, testUnionFind.inSameGroup(2,3), "2 and 3 are not in the same group");
+
+    var supremeLeader = testUnionFind.find(0).getGroupLeader();
+    assert.equal(testUnionFind.find(1).getGroupLeader(), supremeLeader);
+    assert.equal(testUnionFind.find(2).getGroupLeader(), supremeLeader);
+    assert.equal(testUnionFind.find(3).getGroupLeader(), supremeLeader);
+  });
 });

--- a/unionFind.js
+++ b/unionFind.js
@@ -1,43 +1,40 @@
 function Group (node) {
-  this.nodes = [];
-
   this.leader = node;
-  this.nodes.push(node);
   this.groupSize = 1;
 };
 
 Group.prototype.mergeGroup = function (sourceGroup) {
   this.groupSize += sourceGroup.groupSize;
-  this.nodes = this.nodes.concat(sourceGroup.nodes);
-};
-
-Group.prototype.mergeIntoGroup = function (targetGroup, nodelist) {
-  for (var i = 0; i < this.nodes.length; i++) {
-    nodelist[this.nodes[i]].group = targetGroup;
-  }
+  sourceGroup.leader.group = this;  
 };
 
 function Node (node) {
   this.node = node;
-  this.group = new Group(node);
+  this.group = new Group(this);
 };
 
 Node.prototype.changeGroup = function (targetNode, nodelist) {
-  targetNode.group.mergeGroup(this.group);
-
-  this.group.mergeIntoGroup(targetNode.group, nodelist);
+  targetNode.getGroup().mergeGroup(this.getGroup());
 };
 
 Node.prototype.equals = function (otherNode) {
-  return this.group.leader == otherNode.group.leader;
+  return this.getGroup() == otherNode.getGroup();
 };
 
 Node.prototype.getGroupSize = function () {
-  return this.group.groupSize;
+  return this.getGroup().groupSize;
 };
 
 Node.prototype.getGroupLeader = function () {
-  return this.group.leader;
+  return this.getGroup().leader.node;
+}
+
+Node.prototype.getGroup = function() {
+  var group = this.group;
+  while (group.leader.group != group) {
+    group = group.leader.group;
+  }
+  return group;
 };
 
 function UnionFind (nodes) {


### PR DESCRIPTION
Instead of iterating over all nodes in a group and changing their
leader, instead I point the leader to the new “super” group and added a
getGroup() method that follows the chain of leaders until the top one
is found.

Basically I found that maintaining and updating the child nodes within
a group became very expensive (computationally and memory-wise) at
large node numbers and this fix solves the problem at the expense of
worsening the performance of inSameGroup(). However, I think this is
the right trade-off for how I suspect this data structure may be used.